### PR TITLE
Fixin Type on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ await scaffold({
 
 1. Fork the repository
 2. Add templates to your own Github account
-3. Add the package deetails and repo URL to `constants/templates.js` without the `https://github.com/` prefix
+3. Add the package details and repo URL to `constants/templates.js` without the `https://github.com/` prefix
 ```js
 const EXPRESS_TEMPLATES = [
   {


### PR DESCRIPTION
Replaced the word "deetails" to "details" on the README.md

<img width="1180" alt="Screenshot 2025-05-15 at 14 56 30" src="https://github.com/user-attachments/assets/2958ed93-54ed-408f-9a80-504231b5b584" />

Closes #23 